### PR TITLE
Better error messages. Don't continue collecting errors assuming a ta…

### DIFF
--- a/src/XmlParse.hs
+++ b/src/XmlParse.hs
@@ -24,6 +24,11 @@ import Config
 -- Parsing of XML to create instances of Builder --
 ---------------------------------------------------
 
+tBuilder, tSetProperty, tShell :: String
+tBuilder = "builder"
+tSetProperty = "setProperty"
+tShell = "shell"
+
 giveLineInMsg :: String -> Maybe Line -> String
 giveLineInMsg errMsg Nothing = errMsg
 giveLineInMsg errMsg (Just line) = "At line " ++ show line ++ ": " ++ errMsg
@@ -33,34 +38,27 @@ data ZXML = ZElem {tag :: String, attrs :: [(String, String)], children :: [ZXML
 data XmlParsingError
   = EmptyDocument
   | MissingAttribute String String
-  | UnexpectedTag String String (Maybe Line) -- ^ The expected tag, the actual tag
+  | UnexpectedTag [String] String (Maybe Line) -- ^ The expected tags, the actual tag
   | UnexpectedText (Maybe Line)
   | UnexpectedCRef
-  | UnrecognizedStep (Maybe Line)
   deriving (Eq, Ord)
 
 instance Show XmlParsingError where
   show EmptyDocument = "The document is empty"
-  show (MissingAttribute elem attr) = "Missing attribute in element " ++ elem ++ ": " ++ attr
-  show (UnexpectedTag expected actual line) = giveLineInMsg ("Expected " ++ expected ++ ", got " ++ actual) line
+  show (MissingAttribute elem attr) =
+    "Missing attribute in element " ++ elem ++ ": " ++ attr
+  show (UnexpectedTag expected actual line) =
+    giveLineInMsg
+      ("Expected one of " ++ intercalate ", " expected ++ ", got " ++ actual)
+      line
   show (UnexpectedText cdLine) = giveLineInMsg "Unexpected Text in XML" cdLine
   show UnexpectedCRef = "Unexpected CRef in XML"
-  show (UnrecognizedStep cdLine) = giveLineInMsg "Unrecognized step" cdLine
 
 type XmlParsingErrors = Set.Set XmlParsingError
 type XmlValidation = Validation XmlParsingErrors
 
 failWith :: XmlParsingError -> XmlValidation a
 failWith error = Failure (Set.singleton error)
-
-checkTag :: String -- ^ The expected tag
-         -> ZXML   -- ^ The element to check
-         -> XmlValidation ()
--- ^ Checks that the tag is the first argument.
-checkTag tag ZElem {tag=actual, maybeLine} =
-  if actual == tag
-    then Success ()
-    else failWith (UnexpectedTag tag actual maybeLine)
 
 getAttrValue :: String -- ^ The element in which the attribute is being searched (for error messages)
              -> String -- ^ The attribute's name
@@ -73,33 +71,31 @@ getAttrValue elem attr attrs =
 
 zxmlToSetPropertyFromValue :: ZXML -> XmlValidation Step
 zxmlToSetPropertyFromValue zxml@ZElem {attrs} = do
-  checkTag tag zxml
-  propArg <- getAttrValue tag "property" attrs
-  valueArg <- getAttrValue tag "value" attrs
+  propArg <- getAttrValue tSetProperty "property" attrs
+  valueArg <- getAttrValue tSetProperty "value" attrs
   return $ SetPropertyFromValue propArg valueArg
-  where tag = "setProperty"
 
 zxmlToShellCmd :: ZXML -> XmlValidation Step
 zxmlToShellCmd zxml@ZElem {attrs} = do
-  checkTag tag zxml
-  cmdArg <- words <$> getAttrValue tag "command" attrs
+  cmdArg <- words <$> getAttrValue tShell "command" attrs
   return $ ShellCmd cmdArg
-  where tag = "shell"
 
-zXMLToStep :: ZXML -> XmlValidation Step
-zXMLToStep zxml =
-  setPropertyFromValue <!> shellCmd <!> failWith (UnrecognizedStep (maybeLine zxml))
-  where setPropertyFromValue = zxmlToSetPropertyFromValue zxml
-        shellCmd = zxmlToShellCmd zxml
+parseStep :: ZXML -> XmlValidation Step
+parseStep zxml@ZElem {tag, maybeLine}
+  | tag == tSetProperty = zxmlToSetPropertyFromValue zxml
+  | tag == tShell = zxmlToShellCmd zxml
+  | otherwise = failWith (UnexpectedTag [tSetProperty, tShell] tag maybeLine)
 
 zXMLToBuilder :: ZXML -> XmlValidation Builder
 zXMLToBuilder zxml@ZElem {attrs, children} = do
-  checkTag tag zxml
-  name <- getAttrValue tag "name" attrs
-  steps <- traverse zXMLToStep children
+  name <- getAttrValue tBuilder "name" attrs
+  steps <- traverse parseStep children
   return $ Builder name steps
- where
-  tag = "builder"
+
+parseBuilder :: ZXML -> XmlValidation Builder
+parseBuilder zxml@ZElem {tag, maybeLine}
+  | tag == tBuilder = zXMLToBuilder zxml
+  | otherwise = failWith (UnexpectedTag [tBuilder] tag maybeLine)
 
 fromJustZXml :: Maybe ZXML -> XmlValidation ZXML
 fromJustZXml = maybe (failWith EmptyDocument) pure
@@ -124,7 +120,7 @@ parseXmlString str = traverse transform (XmlInput.parseXML str)
   transform xml =
     textXMLToZXML xml
       `bindValidation` fromJustZXml
-      `bindValidation` zXMLToBuilder
+      `bindValidation` parseBuilder
 
 parseXmlFile :: String                       -- ^ A filename
              -> IO (XmlValidation [Builder]) -- ^ The builders

--- a/test/XmlParseSpec.hs
+++ b/test/XmlParseSpec.hs
@@ -1,24 +1,33 @@
 module XmlParseSpec (spec) where
 
 import Config
+import Control.Lens.Extras
 import Data.Validation
 import XmlParse
 import System.Exit
 import Test.Hspec
 
-isFailure :: Validation err a -> Bool
-isFailure (Failure _)  = True
-isFailure (Success _)  = False
-
-isSuccess :: Validation err a -> Bool
-isSuccess = not . isFailure
-
 badXml1 = "<foobar></foobar>"
+
+validXml =
+  "<builder name=\"ls builder\">\
+  \  <shell command=\"ls /\"/>\
+  \  <setProperty property=\"prop\" value=\"foobar\"/>\
+  \</builder>"
+
+expectedBuilder =
+  Builder
+    { name = "ls builder"
+    , steps =
+      [ ShellCmd { cmd = ["ls", "/"] }
+      , SetPropertyFromValue { prop = "prop", value = "foobar" }
+      ]
+    }
 
 spec :: SpecWith ()
 spec =
-  describe "testBadTopLevelElement" $
-    it "" $ do
-        print failure1
-        isFailure failure1 `shouldBe` True
-  where failure1 = parseXmlString badXml1
+  describe "parseXmlString" $ do
+    it "should succeed on valid XLM" $
+      parseXmlString validXml `shouldBe` Success [expectedBuilder]
+    it "should fail on bad toplevel element" $
+      parseXmlString badXml1 `shouldSatisfy` is _Failure

--- a/zzbot.cabal
+++ b/zzbot.cabal
@@ -29,6 +29,7 @@ executable zzbot
                        xml-conduit,
 -- Until https://github.com/haskell/haskell-ide-engine/issues/1362 is sorted, we need tests dependencies in main dependencies:
                        hspec,
+                       lens,
                        mtl,
                        QuickCheck
   other-modules:       Config
@@ -43,6 +44,7 @@ test-suite spec
   build-depends:       base >= 4.7 && < 5,
                        containers,
                        either,
+                       lens,
                        prettyprinter,
                        prettyprinter-ansi-terminal,
                        process,


### PR DESCRIPTION
…g was correct if the tag isn't correct. Also return meaningful errors if the tag doesn't match any of the expected tags.