### PR TITLE
add a read-write lock to gate access to the db

### DIFF
--- a/zzbot.cabal
+++ b/zzbot.cabal
@@ -22,6 +22,7 @@ library
   hs-source-dirs:    src
   default-language:  Haskell2010
   build-depends:     base >= 4.7 && < 5,
+                     concurrent-extra,
                      containers,
                      either,
                      extra,


### PR DESCRIPTION
In theory this shouldn't be needed since sqlite should have such a lock but in practice depending on how sqlite is compiled it will return fatal errors or retryable errors (busy) on concurrent read/write or write/write access.