### PR TITLE
use json for representing steps in the DB

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Config (
   applySubstitution
@@ -38,12 +39,14 @@ import Data.Kind
 import Data.Maybe
 import Data.Validation
 import Data.Void
+import GHC.Generics
 import Safe
 import System.FilePath
 import Text.Megaparsec.Char
 import Text.Megaparsec
 import Text.Printf
 
+import qualified Data.Aeson as J
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -86,7 +89,10 @@ type Forall (c :: Type -> Constraint) (p :: Phase) =
   )
 
 data Command = Command { cmdFilename :: String, cmdArgs :: [String] }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance J.ToJSON Command
+instance J.FromJSON Command
 
 data Step (p :: Phase)
   = SetPropertyFromValue { prop :: String, value :: String }
@@ -99,6 +105,9 @@ data Step (p :: Phase)
 
 deriving instance Forall Eq p => Eq (Step p)
 deriving instance Forall Show p => Show (Step p)
+deriving instance Forall Generic p => Generic (Step p)
+instance (Forall J.ToJSON p, Forall Generic p) => J.ToJSON (Step p)
+instance (Forall J.FromJSON p, Forall Generic p) => J.FromJSON (Step p)
 
 {- HLINT ignore ForeachExtension -}
 data ForeachExtension (p :: Phase) = Foreach
@@ -107,6 +116,9 @@ data ForeachExtension (p :: Phase) = Foreach
 
 deriving instance Forall Eq p => Eq (ForeachExtension p)
 deriving instance Forall Show p => Show (ForeachExtension p)
+deriving instance Forall Generic p => Generic (ForeachExtension p)
+instance (Forall J.ToJSON p, Forall Generic p) => J.ToJSON (ForeachExtension p)
+instance (Forall J.FromJSON p, Forall Generic p) => J.FromJSON (ForeachExtension p)
 
 data Builder (p :: Phase) = Builder
   { workdir :: BuilderWorkDirType p
@@ -116,6 +128,9 @@ data Builder (p :: Phase) = Builder
 
 deriving instance Forall Eq p => Eq (Builder p)
 deriving instance Forall Show p => Show (Builder p)
+deriving instance Forall Generic p => Generic (Builder p)
+instance (Forall J.ToJSON p, Forall Generic p) => J.ToJSON (Builder p)
+instance (Forall J.FromJSON p, Forall Generic p) => J.FromJSON (Builder p)
 
 data Config (p :: Phase) = Config
   { builders :: NE.NonEmpty (Builder p)
@@ -124,6 +139,9 @@ data Config (p :: Phase) = Config
 
 deriving instance Forall Eq p => Eq (Config p)
 deriving instance Forall Show p => Show (Config p)
+deriving instance Forall Generic p => Generic (Config p)
+instance (Forall J.ToJSON p, Forall Generic p) => J.ToJSON (Config p)
+instance (Forall J.FromJSON p, Forall Generic p) => J.FromJSON (Config p)
 
 -- types
 type Subst = [(String,String)]

--- a/src/Db.hs
+++ b/src/Db.hs
@@ -8,6 +8,7 @@ module Db where
 
 import Control.Monad.Except
 import Data.List.Extra
+import qualified Data.Aeson as J
 
 import Common
 import Config
@@ -49,7 +50,7 @@ instance LowLevelDbOperations m => DbOperations (UsingLowLevelDb m) where
        buildID <- LowLevelDb.startBuild builderName
        return $ BuildState buildID []
     startStep buildState@(BuildState buildID _) step = UsingLowLevelDb $
-       LowLevelDb.startStep buildID (show step)
+       LowLevelDb.startStep buildID (J.encode step)
     endStep buildState stepID streams status = UsingLowLevelDb $ do
        LowLevelDb.endStep stepID streams status
        return $ Db.snoc buildState status

--- a/src/Db.hs
+++ b/src/Db.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE DataKinds #-}
 
 module Db where
 
@@ -9,6 +10,7 @@ import Control.Monad.Except
 import Data.List.Extra
 
 import Common
+import Config
 import LowLevelDb
 
 -- | The state of a build, as exposed to clients of this file
@@ -22,7 +24,7 @@ snoc (BuildState buildID statuses) status =
 
 class Monad m => DbOperations m where
    startBuild :: String -> m BuildState -- ^ The string is the builder's name
-   startStep :: BuildState -> String -> m StepID -- ^ The string is the step's description
+   startStep :: BuildState -> Step Substituted -> m StepID -- ^ The string is the step's description
    endStep :: BuildState -> StepID -> StepStreams -> Status -> m BuildState -- ^ stdout, stderr, step status
    endBuild :: BuildState -> m Status -- ^ Returns the overall state of the build
 
@@ -46,8 +48,8 @@ instance LowLevelDbOperations m => DbOperations (UsingLowLevelDb m) where
     startBuild builderName = UsingLowLevelDb $ do
        buildID <- LowLevelDb.startBuild builderName
        return $ BuildState buildID []
-    startStep buildState@(BuildState buildID _) desc = UsingLowLevelDb $
-       LowLevelDb.startStep buildID desc
+    startStep buildState@(BuildState buildID _) step = UsingLowLevelDb $
+       LowLevelDb.startStep buildID (show step)
     endStep buildState stepID streams status = UsingLowLevelDb $ do
        LowLevelDb.endStep stepID streams status
        return $ Db.snoc buildState status

--- a/src/Exec.hs
+++ b/src/Exec.hs
@@ -142,7 +142,7 @@ runSteps ctxt@BuildContext{buildState, properties} (step:steps) = do
   step' <- inject
              substitutionErrorCode
              (substitute dynSubstDelimiters (Map.toList properties) step)
-  stepID <- startStep buildState $ show step'
+  stepID <- startStep buildState step'
   (ctxt', streams, status, continue) <- runStep ctxt step'
   endStep (snoc buildState status) stepID streams status
   unless continue $ throwError subprocessErrorCode

--- a/src/LowLevelDb.hs
+++ b/src/LowLevelDb.hs
@@ -23,6 +23,7 @@ import Data.Maybe
 import Common
 import Text.Printf
 
+import qualified Data.ByteString.Lazy as LBS
 import qualified Control.Concurrent.ReadWriteLock as RWL
 import qualified Data.Text as Text
 
@@ -34,7 +35,7 @@ import qualified Data.Text as Text
 -- | The database's structure is documented at the repo's root DEV.md file
 class Monad m => LowLevelDbOperations m where
     startBuild :: String -> m BuildID -- ^ Records start of build with given name, returns the new build's unique identifier
-    startStep :: BuildID -> String -> m StepID -- ^ Records the start of a step, requires its description, returns its unique identifier
+    startStep :: BuildID -> LBS.ByteString -> m StepID -- ^ Records the start of a step, requires its description, returns its unique identifier
     endStep :: StepID -> StepStreams -> Status -> m () -- ^ Records the end of a step, requires its identifier, streams outputs, and its status
     endBuild :: BuildID -> Status -> m () -- ^ End a build: records the end time and the status
 

--- a/zzbot.cabal
+++ b/zzbot.cabal
@@ -22,6 +22,8 @@ library
   hs-source-dirs:    src
   default-language:  Haskell2010
   build-depends:     base >= 4.7 && < 5,
+                     aeson,
+                     bytestring,
                      concurrent-extra,
                      containers,
                      either,


### PR DESCRIPTION
Two things that might be controversial in this PR:
 - LowLevelDb now depends on Config
 - The JSON representation is automatically derived from the datatypes' internal representation, which means that any change to the datatype definition will break backwards compatibility with existing DBs